### PR TITLE
Fix error message when API is uncontactable

### DIFF
--- a/assets_manager/views.py
+++ b/assets_manager/views.py
@@ -75,7 +75,6 @@ def create(request):
 
             # Create all files
             for asset_file in files:
-                template = "created.html"
 
                 try:
                     response = mapper.create(
@@ -95,8 +94,11 @@ def create(request):
                         # Success
                         created_assets.append(response)
 
-                except RequestException as error:
-                    api_error(error)
+                except RequestException as request_error:
+                    error = api_error(request_error).content
+
+            if not error:
+                template = "created.html"
 
         else:
             error = "Please select files to upload"


### PR DESCRIPTION
# Step to reproduce
- run `manager.assets.ubuntu.com`  without the `assets.ubuntu.com`
- [0.0.0.0:8018/create](http://0.0.0.0:8018/create)
- Submit an asset with a file and a tag
- `local variable 'error' referenced before assignment`
![selection_002](https://user-images.githubusercontent.com/2707508/31390145-001708ba-adcb-11e7-83ac-9ea890e8755d.png)

# Now
- instead of getting the django error: redirects on the create asset page and shows an error message
![selection_001](https://user-images.githubusercontent.com/2707508/31390142-fdddc4f8-adca-11e7-8521-a1ac737b2fbf.png)


