### PR TITLE
Add python-futures and python 2/3 compatibility

### DIFF
--- a/assets_manager/lib/http_helpers.py
+++ b/assets_manager/lib/http_helpers.py
@@ -1,3 +1,11 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases() # noqa
+
+
 def files_from_request_form(request, key):
     """
     Given a request containing files submitted

--- a/assets_manager/mappers.py
+++ b/assets_manager/mappers.py
@@ -1,3 +1,12 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from builtins import dict
+from builtins import object
+from future import standard_library
+standard_library.install_aliases() # noqa
+
 # System
 import mimetypes
 from base64 import b64encode
@@ -6,7 +15,7 @@ try:
         parse_qsl, urlencode, urljoin, urlparse, urlunparse
     )
 except ImportError:
-    from urlparse import (
+    from urllib.parse import (
         parse_qsl, urlencode, urljoin, urlparse, urlunparse
     )
 
@@ -28,7 +37,7 @@ def add_query_params(url, params):
     return urlunparse(url_parts)
 
 
-class AssetMapper:
+class AssetMapper(object):
     """
     Map data from the Assets API into model objects
     """

--- a/assets_manager/migrations/0001_initial.py
+++ b/assets_manager/migrations/0001_initial.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases() # noqa
 
 from django.db import migrations
 from django.contrib.auth.models import Group

--- a/assets_manager/settings.py
+++ b/assets_manager/settings.py
@@ -1,8 +1,24 @@
 """
 Assets manager settings
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases() # noqa
+
 import os
 import sys
+
+
+def to_unicode(string):
+    """Convert a string to a Unicode string for Python 2."""
+    try:
+        return unicode(string)
+    except NameError:
+        return string
+
 
 SECRET_KEY = os.environ.get('SECRET_KEY', 'no_secret')
 
@@ -49,10 +65,10 @@ STATICFILES_FINDERS = ['django_static_root_finder.finders.StaticRootFinder']
 
 # Assets server connection
 # ===
-SERVER_URL = os.environ['WEBSERVICE_URL']
+SERVER_URL = to_unicode(os.environ['WEBSERVICE_URL'])
 
 # You must pass the AUTH_TOKEN as an environment variable
-AUTH_TOKEN = os.environ['AUTH_TOKEN']
+AUTH_TOKEN = to_unicode(os.environ['AUTH_TOKEN'])
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 

--- a/assets_manager/urls.py
+++ b/assets_manager/urls.py
@@ -1,3 +1,10 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases() # noqa
+
 # Third party imports
 from django.conf.urls import url, include
 from django.contrib import admin

--- a/assets_manager/views.py
+++ b/assets_manager/views.py
@@ -1,3 +1,10 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases() # noqa
+
 # Packages
 from django.shortcuts import render
 from django.http import HttpResponse, HttpResponseNotFound
@@ -6,7 +13,7 @@ from requests.exceptions import RequestException
 try:
     from urllib.parse import urljoin
 except ImportError:
-    from urlparse import urljoin
+    from urllib.parse import urljoin
 from django.contrib.auth.decorators import login_required
 
 # Local

--- a/assets_manager/wsgi.py
+++ b/assets_manager/wsgi.py
@@ -1,6 +1,12 @@
 """
 WSGI config for webapp project.
 """
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases() # noqa
 
 import os
 import sys

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,14 @@
 #! /usr/bin/env python3
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases() # noqa
+
 import os
 import sys
+
 
 if __name__ == "__main__":
     os.environ.setdefault(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Django==1.11.1
 requests==2.3.0
 django-static-root-finder==0.1.1
 dj-database-url==0.3.0
+future==0.16.0
 psycopg2==2.6.1
 python-openid==2.2.5
 django-openid-auth==0.14


### PR DESCRIPTION
Add python-future package and run the automatic tool (with some tidying up) to enable python 2 and 3 support.
There were some errors which tracked back to the `os.environ` based settings not being set as unicode in Python 2, so a wrapper

Fixes #45

## QA

The ./run script only uses Python 3, so we will have to do a few manual steps:

First, start up the [Assets server](https://github.com/canonical-websites/assets.ubuntu.com)
Follow the instructions to [get a token](https://github.com/canonical-websites/assets.ubuntu.com#tokens)

Now we will want to set up environment variables in the shell you use to run this server, filling in AUTH_TOKEN with the generated token
```
export WEBSERVICE_URL="http://localhost:8018"
export AUTH_TOKEN=""
export DATABASE_URL="sqlite:///./localdb.sqlite"
export DJANGO_DEBUG=true
```

Set up virtual environmens in your favourite manager. Example:
```
virtualenv env2
python3 -m venv env3
env2/bin/pip install -r requirements.txt
env3/bin/pip install -r requirements.txt
```

Try running the site and testing them in the browser:
```

# Run with python2
env2/bin/python manage.py migrate
env2/bin/python manage.py runserver

# Run with python3 (and delete database from python 2 run)
rm localdb.sqlite
env3/bin/python manage.py migrate
env3/bin/python manage.py runserver
```